### PR TITLE
urb: specify shared library path for rbtest

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 CFLAGS = -g -O2
 
 rbtest: liburb.so rbtree_test.o
-	gcc $(CFLAGS) -L. -o rbtest rbtree_test.o -lurb
+	gcc $(CFLAGS) -L. -Wl,-rpath=. -o rbtest rbtree_test.o -lurb
 
 liburb.so: rbtree.o
 	gcc -shared -o liburb.so rbtree.o


### PR DESCRIPTION
This is to simplify the execution of rbtest without need to specify the LD_LIBRARY_PATH.
At least on my system (Debian 11) it didn't link without that. However maybe it was intentional.